### PR TITLE
feat: accept token as input

### DIFF
--- a/.github/workflows/pr-action-docs.yaml
+++ b/.github/workflows/pr-action-docs.yaml
@@ -16,5 +16,7 @@ jobs:
     name: Document GitHub action
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Generate action docs
         uses: ./

--- a/.github/workflows/pr-action-docs.yaml
+++ b/.github/workflows/pr-action-docs.yaml
@@ -16,7 +16,5 @@ jobs:
     name: Document GitHub action
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: Generate action docs
         uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,11 @@ branding:
   color: "green"
   icon: "book-open"
 inputs:
+  TOKEN:
+    description: "GitHub token to use to commit the documentation changes. Use a PAT or a GH App token if your workflow triggers other workflows."
+    type: string
+    required: false
+    default: ${{ github.token }}
   ACTION_FILE_NAME:
     description: "The name of the file to be processed"
     required: true
@@ -37,3 +42,4 @@ runs:
     - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Updated github-action-docs
+        token: ${{ inputs.TOKEN }}


### PR DESCRIPTION
Allows action to commit using a token different than `GITHUB_TOKEN`