### PR TITLE
fix: Bump pyyaml and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,11 @@ To develop locally, install requirements to ensure the .env file is used in the 
 
 ```
 pip3 install -r requirements.txt
+pip3 install -r requirements-dev.txt
+```
+
+Then run the action locally:
+
+```bash
+python3 main.py
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+python-dotenv == 1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-python-dotenv == 1.1.0
-pyyaml == 6.0.1
+pyyaml == 6.0.2


### PR DESCRIPTION
* Remove `python-dotenv` from requirements.txt as this is only used for local development
* Bump version of `pyyaml` to `6.0.2`
* Updated docs with local development instructions